### PR TITLE
Resolve : build error caused by import org.junit.Test on Inhousekitch…

### DIFF
--- a/src/test/java/com/ajouict/inhousekitchen/InhousekitchenApplicationTests.java
+++ b/src/test/java/com/ajouict/inhousekitchen/InhousekitchenApplicationTests.java
@@ -9,5 +9,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest
 public class InhousekitchenApplicationTests {
 
+    @Test
+    public void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
…enApplicationTest.java
Junit의 클래스 임포트 비활성화와 @Test contextLoads 함수의 부재로 인한 빌드 오류